### PR TITLE
chore: repo standardization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @XhinLiang

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a reproducible problem
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+Describe the bug clearly.
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+Describe what you expected to happen.
+
+## Actual behavior
+
+Describe what happened instead.
+
+## Environment
+
+- OS:
+- JDK version:
+- Maven version:
+- Library version:
+
+## Additional context
+
+Add logs, stack traces, or screenshots if helpful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Usage question
+    url: https://github.com/XhinLiang/LunarCalendar/discussions
+    about: Please use Discussions for general questions and usage help.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What problem does this solve?
+
+## Proposed solution
+
+Describe your proposed approach.
+
+## Alternatives considered
+
+List any alternatives you considered.
+
+## Additional context
+
+Add examples, references, or use cases.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## What changed
+
+- 
+
+## Why
+
+- 
+
+## Checklist
+
+- [ ] I ran `mvn -B -ntp clean verify` locally (or explained why not).
+- [ ] I added or updated tests when behavior changed.
+- [ ] I updated docs/README when user-facing usage changed.
+- [ ] CI passes for this PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: maven
+
+      - name: Build and verify
+        run: mvn -B -ntp clean verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to LunarCalendar
+
+Thanks for contributing.
+
+## Development setup
+
+- JDK 8 or newer (Temurin recommended)
+- Maven 3.6+
+
+## Build and test
+
+Run the project quality gate locally before opening a pull request:
+
+```bash
+mvn -B -ntp clean verify
+```
+
+## Pull requests
+
+1. Create a branch from `master`.
+2. Keep changes focused and include tests when behavior changes.
+3. Update documentation when public usage changes.
+4. Ensure CI is green.
+
+## Commit messages
+
+Use concise, descriptive commit messages (for example, `chore: repo standardization`).
+
+## Reporting issues
+
+Use the issue templates for bugs and feature requests.

--- a/README-CN.md
+++ b/README-CN.md
@@ -1,4 +1,5 @@
 # LunarCalendar
+[![CI](https://github.com/XhinLiang/LunarCalendar/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/XhinLiang/LunarCalendar/actions/workflows/ci.yml)
 [![Jitpack](https://jitpack.io/v/XhinLiang/LunarCalendar.svg)](https://jitpack.io/#XhinLiang/LunarCalendar)
 [![Release](https://img.shields.io/github/release/XhinLiang/LunarCalendar.svg)](https://jitpack.io/#XhinLiang/LunarCalendar)
 
@@ -75,6 +76,14 @@ Month of Lunar
 - 在 **Main** 中找到示例代码
 - 在 **根目录** 找到 **JavaDoc**
 
+## 开发
+- 环境要求：JDK 8+，Maven 3.6+
+- 本地质量检查：
+```
+mvn -B -ntp clean verify
+```
+- GitHub Actions 会在 push 和 pull request 中执行同样的命令。
+
 ## 更多
 - XhinLiang@gmail.com
 - [Blog](http://xhinliang.github.io)
@@ -98,5 +107,4 @@ Month of Lunar
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # LunarCalendar
+[![CI](https://github.com/XhinLiang/LunarCalendar/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/XhinLiang/LunarCalendar/actions/workflows/ci.yml)
 [![Release](https://jitpack.io/v/XhinLiang/LunarCalendar.svg)](https://jitpack.io/#XhinLiang/LunarCalendar)
 [![Release](https://img.shields.io/github/release/XhinLiang/LunarCalendar.svg)](https://jitpack.io/#XhinLiang/LunarCalendar)
 
@@ -72,6 +73,14 @@ for (LunarCalendar[] week : month) {
 - View the sample in **Main**
 - View the doc in **root**
 
+## Development
+- Requirements: JDK 8+ and Maven 3.6+
+- Run local quality checks:
+```
+mvn -B -ntp clean verify
+```
+- CI runs the same command on GitHub Actions for pushes and pull requests.
+
 ## More
 - XhinLiang@gmail.com
 - [Blog](https://xhinliang.com)
@@ -95,5 +104,4 @@ for (LunarCalendar[] week : month) {
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-
 


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow at `.github/workflows/ci.yml` using Temurin JDK and Maven cache
- add repository community standards: `CONTRIBUTING.md`, `.github/CODEOWNERS`, issue templates, and pull request template
- refresh `README.md` and `README-CN.md` with CI badge and development instructions

## Validation
- local `mvn -B -ntp clean verify` could not run in this environment because `mvn` is not installed (`mvn: command not found`)
- CI workflow runs `mvn -B -ntp clean verify` on GitHub Actions to validate builds/tests